### PR TITLE
Do not switch to mobile Safari for local links

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -12,6 +12,7 @@
     <link rel="icon" type="image/png" sizes="16x16" href="{{ site.baseurl }}/favicon-16x16.png?v={{v}}">
     <link rel="manifest" href="{{ site.baseurl }}/site.webmanifest?v={{v}}">
     <link rel="mask-icon" href="{{ site.baseurl }}/safari-pinned-tab.svg?v={{v}}" color="#438dcc">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-title" content="Eucharistie">
     <meta name="application-name" content="Eucharistie">
     <meta name="msapplication-TileColor" content="#2d89ef">

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -99,6 +99,23 @@
     <link rel="stylesheet" href="{{ '/assets/css/flatpickr.min.css' | relative_url }}">
     <script src="{{ '/assets/js/flatpickr.js' | relative_url }}"></script>
     <script src="{{ '/assets/js/flatpickr.nl.js' | relative_url }}"></script>
+    <script>
+      if(("standalone" in window.navigator) && window.navigator.standalone){
+        // If you want to prevent remote links in standalone web apps opening Mobile Safari, change 'remotes' to true
+        var noddy, remotes = false;
+        document.addEventListener('click', function(event) {
+          noddy = event.target;
+          // Bubble up until we hit link or top HTML element. Warning: BODY element is not compulsory so better to stop on HTML
+          while(noddy.nodeName !== "A" && noddy.nodeName !== "HTML") {
+              noddy = noddy.parentNode;
+          }
+          if('href' in noddy && noddy.href.indexOf('http') !== -1 && (noddy.href.indexOf(document.location.host) !== -1 || remotes)) {
+            event.preventDefault();
+            document.location.href = noddy.href;
+          }
+        } ,false);
+      }
+    </script>
   </head>
   <body data-page="{{page.name}}">
     <div hidden>

--- a/docs/_layouts/main.html
+++ b/docs/_layouts/main.html
@@ -2,7 +2,7 @@
 layout: home
 ---
 <div class="container-lg clearfix d-flex flex-column flex-md-row flex-items-stretch rounded-md-bottom-2" id="main">
-  <div class="d-md-block unhide-md slide-up" hidden id="SideNav">
+  <div class="d-md-block unhide-md slide-up" hidden id="SideNav" style="flex-shrink: 0;">
     {% include sidenav.html %}
   </div>
   <div class="m-md-3 p-0 flex-auto nav-{{page.sideNav}}">

--- a/docs/_layouts/u2.html
+++ b/docs/_layouts/u2.html
@@ -89,6 +89,29 @@ layout: main
       {{channel | where_exp: "hash", "hash[0] != 'output'" | where_exp: "hash", "hash[0] != 'next' and hash[0] != 'previous'"  | jsonify}},
     {% endfor %}
   ];
+
+  // POLYFILLS
+  if (Object.fromEntries == undefined) {
+    Object.fromEntries = function(entries) {
+      const object = {}
+      for (var tuple of entries)
+        object[tuple[0]] = tuple[1]
+      return object
+    }
+  }
+  if (window.Intl == undefined) {
+    Intl = {
+      DateTimeFormat: function() {
+        return {
+          format: function(date) {
+            const minutes = ("0" + date.getMinutes())
+            return date.getHours() + ":" + minutes.substr(minutes.length - 2)
+          }
+        }
+      }
+    }
+  }
+
   const channels = channelEntries.map(function (entries) {return Object.fromEntries(entries)});
   const localDays = {{localDays|jsonify}};
   const languageNames = {{languageNames|jsonify}};
@@ -132,10 +155,10 @@ layout: main
     return dateShort;
   }
 
-  let dateToShow = shortDate(new Date())
+  var dateToShow = shortDate(new Date())
 
   // Find used languages
-  let languages = new Set();
+  var languages = new Set();
   channels.forEach( function(channel) {
     if (channel.timetable && Array.isArray(channel.timetable)) {
       channel.timetable.forEach( function (event) {
@@ -266,7 +289,7 @@ layout: main
 
         // event has exlude dates
         const excludesThisDate = event.event.excludingDates && Array.isArray(event.event.excludingDates) && (event.event.excludingDates.indexOf(date) >= 0);
-        let hidden = notThisDate || excludesThisDate || notThisLang
+        var hidden = notThisDate || excludesThisDate || notThisLang
 
         if (hidden) {
           eventCount--;
@@ -284,7 +307,7 @@ layout: main
     datePickerMobile.setDate(new Date(newdate), true);
   }
 
-  let calendar = generateCalendar();
+  var calendar = generateCalendar();
   // show today
   showDate(dateToShow);
 


### PR DESCRIPTION
When installing this website as a mobile app on iOS and you tap on links, the links don't open in the same app but it switches to mobile Safari and opens them there instead.
This little script forces local links to open within the same app.